### PR TITLE
add Snort integration with Wazuh for macOS M1

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,10 @@ Install using this command:
    sudo curl -SL https://raw.githubusercontent.com/ADORSYS-GIS/wazuh-snort/main/scripts/install.sh | bash
    ```
 ## Installation (MacOS)
-
    Install using this command:
-      ```bash
+   ```bash
       curl -SL https://raw.githubusercontent.com/ADORSYS-GIS/wazuh-snort/main/scripts/install.sh | bash
-      ```
+   ```
 
 ## Description
 

--- a/README.md
+++ b/README.md
@@ -31,11 +31,18 @@ This repository contains several resources for installing and configuring Snort,
 ### Prerequisites
 - Wazuh Agent installed on endpoints
 
-### Installation
+### Installation 
+## Installation (Linux)
 Install using this command:
    ```bash
    sudo curl -SL https://raw.githubusercontent.com/ADORSYS-GIS/wazuh-snort/main/scripts/install.sh | bash
    ```
+## Installation (MacOS)
+
+   Install using this command:
+      ```bash
+      curl -SL https://raw.githubusercontent.com/ADORSYS-GIS/wazuh-snort/main/scripts/install.sh | bash
+      ```
 
 ## Description
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -158,7 +158,7 @@ update_ossec_conf_macos() {
     info_message "Updating $OSSEC_CONF_PATH"
     
     # Add the Snort configuration to ossec.conf
-    if ! grep -q "$content_to_add" "$OSSEC_CONF_PATH"; then
+    if !  sudo grep -q "$content_to_add" "$OSSEC_CONF_PATH"; then
         sudo sed -i '' -e "/<\/ossec_config>/i\\
 <!-- snort -->\\
 <localfile>\\

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -81,7 +81,7 @@ create_snort_files() {
 # Function to install Snort on macOS
 install_snort_macos() {
     print_step "Installing" "Snort for macOS"
-    maybe_sudo brew install snort
+    brew install snort
 
     create_snort_dirs_files /usr/local/etc/rules /usr/local/etc/so_rules /usr/local/etc/lists /var/log/snort
     create_snort_files /usr/local/etc/rules/local.rules /usr/local/etc/lists/default.blocklist

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -81,7 +81,7 @@ create_snort_files() {
 # Function to install Snort on macOS
 install_snort_macos() {
     print_step "Installing" "Snort for macOS"
-    # Install brew
+    # Install brew if it doesn't exist
     if ! command -v brew &> /dev/null; then
         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -161,15 +161,14 @@ configure_snort_logging_macos() {
 update_ossec_conf_macos() {
     info_message "Updating $OSSEC_CONF_PATH"
 
-    if [[ $ARCH == "arm64" ]]; then
-        # ARM (M1) specific Snort configuration
-        content_to_add="<!-- snort -->
+    content_to_add="<!-- snort -->
 <localfile>
     <log_format>snort-full</log_format>
     <location>/var/log/snort/alert_fast.txt</location>
 </localfile>"
 
-        # Check and add Snort config if not present
+    if [[ $ARCH == "arm64" ]]; then
+        # ARM (M1) specific Snort configuration
         if ! sudo grep -q "$content_to_add" "$OSSEC_CONF_PATH"; then
             sudo sed -i '' -e "/<\/ossec_config>/i\\
 <!-- snort -->\\
@@ -183,22 +182,20 @@ update_ossec_conf_macos() {
         fi
     else
         # Intel specific Snort configuration
-        content_to_add="<!-- snort -->
-<localfile>
-    <log_format>snort-full<\/log_format>
-    <location>\/usr\/local\/var\/log\/snort\/alert_fast.txt<\/location>
-<\/localfile>"
-
-        # Check and add Snort config if not present
         if ! grep -q "$content_to_add" "$OSSEC_CONF_PATH"; then
             maybe_sudo sed -i '' "/<\/ossec_config>/i\\
-    $content_to_add" "$OSSEC_CONF_PATH"
+<!-- snort -->\\
+<localfile>\\
+    <log_format>snort-full</log_format>\\
+    <location>/var/log/snort/alert_fast.txt</location>\\
+</localfile>" "$OSSEC_CONF_PATH"
             success_message "ossec.conf updated on macOS Intel"
         else
             info_message "The content already exists in $OSSEC_CONF_PATH"
         fi
     fi
 }
+
 
 
 # Function to start Snort on macOS

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -80,8 +80,18 @@ create_snort_files() {
 
 # Function to install Snort on macOS
 install_snort_macos() {
-    print_step "Installing" "Snort for macOS"
-    brew install snort
+    # Check if the architecture is M1/ARM or Intel
+    ARCH=$(uname -m)
+    
+    print_step "Installing" "Snort for macOS ($ARCH)"
+    
+    if [[ $ARCH == "arm64" ]]; then
+        maybe_sudo brew install snort
+        SNORT_CONF_PATH="/opt/homebrew/etc/snort/snort.lua"
+    else
+        maybe_sudo brew install snort
+        SNORT_CONF_PATH="/usr/local/etc/snort/snort.lua"
+    fi
 
     create_snort_dirs_files /usr/local/etc/rules /usr/local/etc/so_rules /usr/local/etc/lists /var/log/snort
     create_snort_files /usr/local/etc/rules/local.rules /usr/local/etc/lists/default.blocklist
@@ -135,7 +145,7 @@ install_snort_linux() {
 
 # Function to configure Snort logging on macOS
 configure_snort_logging_macos() {
-    local config_file="/opt/homebrew/etc/snort/snort.lua"
+    local config_file="$SNORT_CONF_PATH"
     local content_to_add='alert_fast =\n{\n    file = true\n}'
 
     info_message "Configuring Snort logging"
@@ -149,35 +159,35 @@ configure_snort_logging_macos() {
 
 # Function to update ossec.conf on macOS
 update_ossec_conf_macos() {
-    local content_to_add="<!-- snort -->
-    <localfile>
-        <log_format>snort-full</log_format>
-        <location>/var/log/snort/alert_fast.txt</location>
-    </localfile>"
-
     info_message "Updating $OSSEC_CONF_PATH"
+
+    if [[ $ARCH == "arm64" ]]; then
+        content_to_add="<!-- snort -->
+        <localfile>
+            <log_format>snort-full</log_format>
+            <location>/var/log/snort/alert_fast.txt</location>
+        </localfile>"
+    else
+        content_to_add="<!-- snort -->
+        <localfile>
+            <log_format>snort-full</log_format>
+            <location>/usr/local/var/log/snort/alert_fast.txt</location>
+        </localfile>"
+    fi
     
-    # Add the Snort configuration to ossec.conf
-    if !  sudo grep -q "$content_to_add" "$OSSEC_CONF_PATH"; then
-        sudo sed -i '' -e "/<\/ossec_config>/i\\
-<!-- snort -->\\
-<localfile>\\
-    <log_format>snort-full</log_format>\\
-    <location>/var/log/snort/alert_fast.txt</location>\\
-</localfile>" "$OSSEC_CONF_PATH"
-        
+    if ! grep -q "$content_to_add" "$OSSEC_CONF_PATH"; then
+        maybe_sudo sed -i '' "/<\/ossec_config>/i\\
+    $content_to_add" "$OSSEC_CONF_PATH"
         success_message "ossec.conf updated on macOS"
     else
         info_message "The content already exists in $OSSEC_CONF_PATH"
     fi
 }
 
-
-
 # Function to start Snort on macOS
 start_snort_macos() {
     info_message "Starting Snort"
-    maybe_sudo snort -c /opt/homebrew/etc/snort/snort.lua -R /usr/local/etc/rules/local.rules -i en0 -A fast -q -D -l /var/log/snort
+    maybe_sudo snort -c "$SNORT_CONF_PATH" -R /usr/local/etc/rules/local.rules -i en0 -A fast -q -D -l /var/log/snort
     success_message "Snort started on macOS"
 }
 
@@ -219,13 +229,13 @@ start_snort_linux() {
     success_message "Snort started on Linux"
 }
 
-# Function to ensure the script runs with root privileges
+# Function to ensure the script runs with appropriate privileges
 maybe_sudo() {
-    if [ "$(id -u)" -ne 0 ]; then
-        if command -v sudo >/dev/null 2>&1; then
+    if [ "$EUID" -ne 0 ]; then
+        if command -v sudo &>/dev/null; then
             sudo "$@"
         else
-            error_message "This script requires root privileges. Please run with sudo or as root."
+            error_message "Please run the script as root or install sudo."
             exit 1
         fi
     else
@@ -233,22 +243,16 @@ maybe_sudo() {
     fi
 }
 
-# Main function to install and configure Snort
-install_snort() {
-    case "$OSTYPE" in
-        darwin*)
-            install_snort_macos
-            ;;
-        linux*)
-            install_snort_linux
-            ;;
-        *)
-            error_message "Unsupported OS type: $OSTYPE"
-            exit 1
-            ;;
-    esac
-}
-
-# Run the main installation function
-install_snort
-
+# Main logic: install Snort based on the operating system
+case "$OS_NAME" in
+    Linux)
+        install_snort_linux
+        ;;
+    Darwin)
+        install_snort_macos
+        ;;
+    *)
+        error_message "Unsupported OS: $OS_NAME"
+        exit 1
+        ;;
+esac

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -83,7 +83,7 @@ install_snort_macos() {
     print_step "Installing" "Snort for macOS"
     # Install brew if it doesn't exist
     if ! command -v brew &> /dev/null; then
-        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh
     fi
     brew install snort
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -81,7 +81,7 @@ create_snort_files() {
 # Function to install Snort on macOS
 install_snort_macos() {
     print_step "Installing" "Snort for macOS"
-    brew install snort
+    maybe_sudo brew install snort
 
     create_snort_dirs_files /usr/local/etc/rules /usr/local/etc/so_rules /usr/local/etc/lists /var/log/snort
     create_snort_files /usr/local/etc/rules/local.rules /usr/local/etc/lists/default.blocklist

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -81,6 +81,10 @@ create_snort_files() {
 # Function to install Snort on macOS
 install_snort_macos() {
     print_step "Installing" "Snort for macOS"
+    # Install brew
+    if ! command -v brew &> /dev/null; then
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    fi
     brew install snort
 
     create_snort_dirs_files /usr/local/etc/rules /usr/local/etc/so_rules /usr/local/etc/lists /var/log/snort

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -86,17 +86,17 @@ install_snort_macos() {
     print_step "Installing" "Snort for macOS ($ARCH)"
     
     if [[ $ARCH == "arm64" ]]; then
-        maybe_sudo brew install snort
+         brew install snort
         SNORT_CONF_PATH="/opt/homebrew/etc/snort/snort.lua"
     else
-        maybe_sudo brew install snort
+         brew install snort
         SNORT_CONF_PATH="/usr/local/etc/snort/snort.lua"
     fi
 
     create_snort_dirs_files /usr/local/etc/rules /usr/local/etc/so_rules /usr/local/etc/lists /var/log/snort
     create_snort_files /usr/local/etc/rules/local.rules /usr/local/etc/lists/default.blocklist
 
-    echo 'alert icmp any any -> any any ( msg:"ICMP Traffic Detected"; sid:10000001; metadata:policy security-ips alert; )' | maybe_sudo tee /usr/local/etc/rules/local.rules > /dev/null
+    echo 'alert icmp any any -> any any ( msg:"ICMP Traffic Detected"; sid:10000001; metadata:policy security-ips alert; )' | sudo tee /usr/local/etc/rules/local.rules > /dev/null
 
     configure_snort_logging_macos
     update_ossec_conf_macos

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -156,14 +156,22 @@ update_ossec_conf_macos() {
     </localfile>"
 
     info_message "Updating $OSSEC_CONF_PATH"
+    
+    # Add the Snort configuration to ossec.conf
     if ! grep -q "$content_to_add" "$OSSEC_CONF_PATH"; then
-        maybe_sudo sed -i '' "/<\/ossec_config>/i\\
-    $content_to_add" "$OSSEC_CONF_PATH"
+        sudo sed -i '' -e "/<\/ossec_config>/i\\
+<!-- snort -->\\
+<localfile>\\
+    <log_format>snort-full</log_format>\\
+    <location>/var/log/snort/alert_fast.txt</location>\\
+</localfile>" "$OSSEC_CONF_PATH"
+        
         success_message "ossec.conf updated on macOS"
     else
         info_message "The content already exists in $OSSEC_CONF_PATH"
     fi
 }
+
 
 
 # Function to start Snort on macOS

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -143,6 +143,20 @@ install_snort_linux() {
     start_snort_linux
 }
 
+# Function to configure Snort logging on macOS
+configure_snort_logging_macos() {
+    local config_file="$SNORT_CONF_PATH"
+    local content_to_add='alert_fast =\n{\n    file = true\n}'
+
+    info_message "Configuring Snort logging"
+    if ! grep -q "$content_to_add" "$config_file"; then
+        echo -e "$content_to_add" | maybe_sudo tee -a "$config_file" > /dev/null
+        success_message "Snort logging configured in $config_file"
+    else
+        info_message "Snort logging is already configured in $config_file"
+    fi
+}
+
 # Function to update ossec.conf on macOS (M1 and Intel)
 update_ossec_conf_macos() {
     local content_to_add="<!-- snort -->

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -135,7 +135,7 @@ install_snort_linux() {
 
 # Function to configure Snort logging on macOS
 configure_snort_logging_macos() {
-    local config_file="/usr/local/etc/snort/snort.lua"
+    local config_file="/opt/homebrew/etc/snort/snort.lua"
     local content_to_add='alert_fast =\n{\n    file = true\n}'
 
     info_message "Configuring Snort logging"
@@ -168,7 +168,7 @@ update_ossec_conf_macos() {
 # Function to start Snort on macOS
 start_snort_macos() {
     info_message "Starting Snort"
-    maybe_sudo snort -c /usr/local/etc/snort/snort.lua -R /usr/local/etc/rules/local.rules -i en0 -A fast -q -D -l /var/log/snort
+    maybe_sudo snort -c /opt/homebrew/etc/snort/snort.lua -R /usr/local/etc/rules/local.rules -i en0 -A fast -q -D -l /var/log/snort
     success_message "Snort started on macOS"
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -192,7 +192,6 @@ $content_to_add" "$OSSEC_CONF_PATH"
 
 
 
-
 # Function to start Snort on macOS
 start_snort_macos() {
     info_message "Starting Snort"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -151,9 +151,9 @@ configure_snort_logging_macos() {
 update_ossec_conf_macos() {
     local content_to_add="<!-- snort -->
     <localfile>
-        <log_format>snort-full<\/log_format>
-        <location>\/var\/log\/snort\/alert_fast.txt<\/location>
-    <\/localfile>"
+        <log_format>snort-full</log_format>
+        <location>/var/log/snort/alert_fast.txt</location>
+    </localfile>"
 
     info_message "Updating $OSSEC_CONF_PATH"
     if ! grep -q "$content_to_add" "$OSSEC_CONF_PATH"; then
@@ -164,6 +164,7 @@ update_ossec_conf_macos() {
         info_message "The content already exists in $OSSEC_CONF_PATH"
     fi
 }
+
 
 # Function to start Snort on macOS
 start_snort_macos() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -81,10 +81,6 @@ create_snort_files() {
 # Function to install Snort on macOS
 install_snort_macos() {
     print_step "Installing" "Snort for macOS"
-    # Install brew if it doesn't exist
-    if ! command -v brew &> /dev/null; then
-    curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh
-    fi
     brew install snort
 
     create_snort_dirs_files /usr/local/etc/rules /usr/local/etc/so_rules /usr/local/etc/lists /var/log/snort


### PR DESCRIPTION
This PR adds support for integrating Snort with Wazuh on macOS M1, following the same integration previously implemented for Intel-based macOS systems.

Key updates include:

Architecture-specific handling using uname -m to differentiate between M1 (arm64) and Intel architectures, ensuring compatibility with both.
Improved logic for detecting Snort configuration in the ossec.conf file by checking for the specific <location> tag, ensuring the correct content is added if not present.
Seamless integration of Snort log parsing in Wazuh on macOS M1, similar to the existing Intel-based integration.
This enhancement ensures Snort logs are properly handled and monitored by Wazuh on both M1 and Intel macOS platforms.






